### PR TITLE
Streamable HTTP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ uv sync
 
 ## Execution
 ```commandline
-PYTHONPATH=. uv run fastmcp run ai_installer_template/server.py --transport sse --port 20000
+PYTHONPATH=. uv run fastmcp run ai_installer_template/server.py --transport http --port 20000
 ```
 
 ## Manual Test using MCP Inspector
@@ -17,13 +17,12 @@ PYTHONPATH=. uv run fastmcp run ai_installer_template/server.py --transport sse 
 uv run fastmcp dev ai_installer_template/server.py
 ```
 
-1. Set Transport Type to SSE
-1. Set URL to http://127.0.0.1:20000/sse/
+1. Set Transport Type to Streamable HTTP
+1. Set URL to http://127.0.0.1:20000/mcp/
 1. Click Connect
 1. Switch to Tools tab
 1. Click List Tools
 1. Click get_template
 1. Set `container` to platform
 1. Set `enterprise` to topology
-1. Set `dummy` to session_id
 1. Click **Run Tool**

--- a/ai_installer_template/server.py
+++ b/ai_installer_template/server.py
@@ -4,7 +4,7 @@ from fastmcp import FastMCP
 mcp = FastMCP("AI Installer Template MCP Server")
 
 @mcp.tool
-def get_template(platform: str, topology: str, session_id: str) -> str:
+def get_template(platform: str, topology: str) -> str:
     """Get a template for AAP Installer for given platform and topology"""
     with importlib.resources.open_text("ai_installer_template.data", f'{platform}_{topology}_template.txt') as f:
         content = f.read()


### PR DESCRIPTION
Switch the current implementation that uses SSE with Streamable HTTP.  It will be merged when llama stack started supporting Streamable HTTP on its MCP support code  (Ref: https://github.com/meta-llama/llama-stack/issues/2542)